### PR TITLE
fix: update breaking change matching

### DIFF
--- a/pkg/semrel/commit.go
+++ b/pkg/semrel/commit.go
@@ -24,25 +24,19 @@ type Commit struct {
 }
 
 func (c *Commit) BumpKind(cfg *Config) BumpKind {
-	keys := make([]string, 0, len(c.Footers))
-
-	for k := range c.Footers {
-		keys = append(keys, k)
-	}
-
-	if c.Attention || FilterFooters(keys) {
+	if c.Attention || FilterFooters(c.Footers) {
 		return BumpMajor
 	}
 
 	return cfg.BumpKind(c.Type)
 }
 
-func FilterFooters(keys []string) bool {
+func FilterFooters(footers map[string]string) bool {
 	isBreakingChange := false
-	for k := range keys {
-		isBreakingChange = breakingPattern.MatchString(keys[k])
+	
+	for k := range c.Footers {
+		isBreakingChange = breakingPattern.MatchString(c.Footers[k])
 	}
-
 	return isBreakingChange
 }
 

--- a/pkg/semrel/commit.go
+++ b/pkg/semrel/commit.go
@@ -24,11 +24,28 @@ type Commit struct {
 }
 
 func (c *Commit) BumpKind(cfg *Config) BumpKind {
-	if c.Attention || breakingPattern.MatchString(c.Body) {
+	keys := make([]string, 0, len(c.Footers))
+
+	for k := range c.Footers {
+		keys = append(keys, k)
+	}
+
+	if c.Attention || FilterFooters(keys) {
 		return BumpMajor
 	}
+
 	return cfg.BumpKind(c.Type)
 }
+
+func FilterFooters(keys []string) bool {
+	isBreakingChange := false
+	for k := range keys {
+		isBreakingChange = breakingPattern.MatchString(keys[k])
+	}
+
+	return isBreakingChange
+}
+
 
 func ParseCommitMessage(message string) (*Commit, error) {
 	lines := strings.Split(message, "\n")


### PR DESCRIPTION
BREAKING CHANGE pattern matching should occur on the `Footers` map instead of in the body of the commit